### PR TITLE
Fixed sample.yaml

### DIFF
--- a/src/walkjump/hydra_config/sample.yaml
+++ b/src/walkjump/hydra_config/sample.yaml
@@ -4,9 +4,10 @@ defaults:
 
 model:
   _target_: walkjump.cmdline.utils.instantiate_model_for_sample_mode
-  model_type: denoise
-  checkpoint_path: ???
-  denoise_path: null
+  sample_mode_model_cfg:
+    model_type: denoise
+    checkpoint_path: "src/walkjump/checkpoints/last.ckpt"
+    denoise_path: null
 
 langevin:
   sigma: 1.0
@@ -14,9 +15,9 @@ langevin:
   lipschitz: 1.0
   friction: 1.0
   steps: 20
-  chunksize: 8
 
 designs:
+  chunksize: 8
   output_csv: samples.csv
   redesign_regions: null
   seeds: denovo
@@ -24,3 +25,4 @@ designs:
   limit_seeds: 10
 
 device: null
+dryrun: false


### PR DESCRIPTION
Key Problem : The sample.py expects args in a dictionary. instantiate_model_for_sample_mode() expects `sample_mode_model_cfg` as an arg. But current hydra config provides `model_type`, `checkpoint_path`, and `denoise_path`. 

Other fixes :

- `chunksize` will be a part of `design` dict, previously was part of `langevin`.
- There was no `dryrun` arg before, now added.
